### PR TITLE
Fixed Bug in manual IRQ raising tests

### DIFF
--- a/rootfs_overlay/pci.sh
+++ b/rootfs_overlay/pci.sh
@@ -40,10 +40,10 @@ dd bs=4 status=none if=/dev/lkmc_pci count=1 skip=8 | od -An -t x1
 # => 1c8cfc00
 
 # Manual IRQ raising.
-printf '\x04\x03\x02\x01' | dd bs=4 status=none of=/dev/lkmc_pci count=1 seek=24
+printf '\x04\x03\x02\x01' | dd bs=4 status=none of=/dev/lkmc_pci count=1 seek=9
 # => irq_handler .*
 sleep 1
-printf '\x08\x07\x06\x05' | dd bs=4 status=none of=/dev/lkmc_pci count=1 seek=24
+printf '\x08\x07\x06\x05' | dd bs=4 status=none of=/dev/lkmc_pci count=1 seek=9
 # => irq_handler .*
 sleep 1
 


### PR DESCRIPTION
Because of the blocksize=4 `dd ... seek=24` would write at position 90.
However manual IRQ raising is positioned at addr=24, which leads to a value of seek=9.