### PR TITLE
configure: Handle non-apt systems

### DIFF
--- a/configure
+++ b/configure
@@ -36,6 +36,16 @@ gcc-arm-linux-gnueabi \
 libgoogle-perftools-dev \
 protobuf-compiler \
 "
+command -v apt-get >/dev/null 2>&1 || {
+    cat <<EOF
+apt-get not found. You're on your own for installing dependencies.
+
+On Ubuntu they are:
+
+$pkgs
+EOF
+    exit 0
+}
 
 sudo apt-get update $y
 # Building SDL for QEMU in Buildroot was rejected upstream because it adds many dependencies:


### PR DESCRIPTION
If apt-get is not found on the host just exit with a message about
installing dependencies.