### PR TITLE
README: fix some error.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3956,7 +3956,7 @@ printf '
 CONFIG_IKCONFIG=y
 CONFIG_IKCONFIG_PROC=y
 ' > data/myconfig
-./build-buildroot --config-fragment 'data/myconfig'
+./build-linux --config-fragment 'data/myconfig'
 ....
 
 To use just your own exact `.config` instead of our defaults ones, use:
@@ -9886,7 +9886,7 @@ The hard part is dealing with crappy third party build systems and huge dependen
 
 We provide the following mechanisms:
 
-* `./build-buildroot --config-fragment data/br2`: append the Buildroot configuration file `data/br2` to a single build. Must be passed every time you run `./build`. The format is the same as link:br2/default[].
+* `./build-buildroot --config-fragment data/br2`: append the Buildroot configuration file `data/br2` to a single build. Must be passed every time you run `./build`. The format is the same as link:buildroot_config/default[].
 * `./build-buildroot --config 'BR2_SOME_OPTION="myval"'`: append a single option to a single build.
 
 For example, if you decide to <<enable-buildroot-compiler-optimizations>> after an initial build is finished, you must <<clean-the-build>> and rebuild:
@@ -9970,7 +9970,7 @@ Save and quit.
 diff -u .config.olg .config
 ....
 
-Then copy and paste the diff additions to link:br2/default[] to make them permanent.
+Then copy and paste the diff additions to link:buildroot_config/default[] to make them permanent.
 
 === Change user
 


### PR DESCRIPTION
I think the `./build-buildroot` should be `./build-linux`

and the dir `br2/default`  has been moved to `buildroot_config/default`
