### PR TITLE
fix git version

### DIFF
--- a/build
+++ b/build
@@ -553,7 +553,7 @@ Which components to build. Default: qemu-buildroot
             else:
                 git_version_tuple = tuple(
                     int(x) for x in self.sh.check_output(['git', '--version']) \
-                    .decode().split(' ')[-1].split('.')
+                            .decode().split(' ')[-1].split('.')[:3]
                 )
                 if git_version_tuple >= (2, 9, 0):
                     # https://stackoverflow.com/questions/26957237/how-to-make-git-clone-faster-with-multiple-threads/52327638#52327638


### PR DESCRIPTION
some git version will contain rcx: 
```
$ git --version
git version 2.23.0.rc0
```
rc0 is not conviertible to int in python, the first three is enough. Otherwise error occur: 
```
ValueError: invalid literal for int() with base 10: 'rc0\n'
```