### PR TITLE
Make '' the default arg for --extra-config-args (instead of None)

### DIFF
--- a/build-qemu
+++ b/build-qemu
@@ -9,7 +9,13 @@ class Main(common.BuildCliFunction):
     def __init__(self):
         super().__init__()
         self._add_argument('--configure')
-        self.add_argument('--extra-config-args')
+        self.add_argument(
+            '--extra-config-args',
+            default='',
+            help='''\
+Extra arguments to pass to configure
+'''
+        )
         self._add_argument('extra_make_args')
 
     def build(self):


### PR DESCRIPTION
or else
./build-qemu
hangs because shlex.split(None) waits for stdin
https://docs.python.org/3/library/shlex.html