### PR TITLE
Misinterpretation of dashes used as separators for init arguments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3435,10 +3435,10 @@ at the very end of the boot logs.
 
 === Init environment
 
-Documented at https://www.kernel.org/doc/html/v4.14/admin-guide/kernel-parameters.html[]:
+Documented at https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html[]:
 
 ____
-The kernel parses parameters from the kernel command line up to "-"; if it doesn't recognize a parameter and it doesn't contain a '.', the parameter gets passed to init: parameters with '=' go into init's environment, others are passed as command line arguments to init. Everything after "-" is passed as an argument to init.
+The kernel parses parameters from the kernel command line up to "--"; if it doesn't recognize a parameter and it doesn't contain a '.', the parameter gets passed to init: parameters with '=' go into init's environment, others are passed as command line arguments to init. Everything after "--" is passed as an argument to init.
 ____
 
 And you can try it out with:
@@ -3450,7 +3450,7 @@ And you can try it out with:
 From the <<dry-run,generated QEMU command>>, we see that the kernel CLI at LKMC 69f5745d3df11d5c741551009df86ea6c61a09cf now contains:
 
 ....
-init=/lkmc/linux/init_env_poweroff.out console=ttyS0 - lkmc_home=/lkmc asdf=qwer zxcv
+init=/lkmc/linux/init_env_poweroff.out console=ttyS0 -- lkmc_home=/lkmc asdf=qwer zxcv
 ....
 
 and the init program outputs:
@@ -3458,14 +3458,13 @@ and the init program outputs:
 ....
 args:
 /lkmc/linux/init_env_poweroff.out
--
+lkmc_home=/lkmc
+asdf=qwer
 zxcv
 
 env:
 HOME=/
 TERM=linux
-lkmc_home=/lkmc
-asdf=qwer
 ....
 
 Source: link:userland/linux/init_env_poweroff.c[].
@@ -6089,7 +6088,7 @@ See also:
 * https://unix.stackexchange.com/questions/48601/how-to-display-the-linux-kernel-command-line-parameters-given-for-the-current-bo
 * https://askubuntu.com/questions/32654/how-do-i-find-the-boot-parameters-used-by-the-running-kernel
 
-The arguments are documented in the kernel documentation: https://www.kernel.org/doc/html/v4.14/admin-guide/kernel-parameters.html
+The arguments are documented in the kernel documentation: https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
 
 When dealing with real boards, extra command line options are provided on some magic bootloader configuration file, e.g.:
 

--- a/run
+++ b/run
@@ -433,7 +433,7 @@ Extra options to append at the end of the emulator command line.
             if self.env['kgdb']:
                 kernel_cli += ' kgdboc={},115200'.format(extra_console)
         if kernel_cli_after_dash:
-            kernel_cli += " -{}".format(kernel_cli_after_dash)
+            kernel_cli += " --{}".format(kernel_cli_after_dash)
         extra_env = {}
         if self.env['trace_insts_stdout']:
             if self.env['emulator'] == 'qemu':

--- a/setup
+++ b/setup
@@ -17,7 +17,7 @@ if [ -f /.dockerenv ]; then
   apt install -y software-properties-common
   add-apt-repository -y ppa:git-core/ppa
   $sudo apt update
-  git='git=1:2.36.*'
+  git='git=1:2.*'
 else
   git=git
 fi


### PR DESCRIPTION
I was going through the guides since I am quite a newbie to whole Linux ecosystem (thank you so much!) and I found that there is a misinterpretation of dash separators for kernel boot parameters, which was probably caused by the formatting bug the official kernel documentation had torvalds/linux@62ee81b5681daa781f5e800346ae8654b3e5a864

I tried to make some fixes to the README.adoc to the main page. Moreover, some of the section of guide may have the content rendered as incorrectly making some conclusion about how parameters are parsed, for example the one where you mention about how `a.b` was parsed
