### PR TITLE
Dockerfile: fix `./run-docker create` fails with `/setup: line 15: sudo: command not found`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # https://cirosantilli.com/linux-kernel-module-cheat#docker
 FROM ubuntu:20.04
+RUN touch /.dockerenv
 COPY setup /
 COPY requirements.txt /
 RUN /setup -y


### PR DESCRIPTION
- adds .dockerenv if not present to invoke ./setup script with correct parameters

This fixes the following:
```
$ docker --version
Docker version 24.0.5, build ced0996
$ ./run-docker create
+ sudo docker build -t lkmc .
[+] Building 0.9s (8/8) FINISHED                                                                                                                                                                                                                                                                                                                                                                     docker:default
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                                                              0.0s
 => => transferring context: 142B                                                                                                                                                                                                                                                                                                                                                                              0.0s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                                                           0.0s
 => => transferring dockerfile: 177B                                                                                                                                                                                                                                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                                                                                                                                                                                                                                                0.5s
 => [1/4] FROM docker.io/library/ubuntu:20.04@sha256:c9820a44b950956a790c354700c1166a7ec648bc0d215fa438d3a339812f1d01                                                                                                                                                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                                                              0.0s
 => => transferring context: 62B                                                                                                                                                                                                                                                                                                                                                                               0.0s
 => CACHED [2/4] COPY setup /                                                                                                                                                                                                                                                                                                                                                                                  0.0s
 => CACHED [3/4] COPY requirements.txt /                                                                                                                                                                                                                                                                                                                                                                       0.0s
 => ERROR [4/4] RUN /setup -y                                                                                                                                                                                                                                                                                                                                                                                  0.3s
------
 > [4/4] RUN /setup -y:
0.292 + '[' 1 -eq 1 ']'
0.292 + y=-y
0.292 + '[' -f /.dockerenv ']'
0.292 + sudo=sudo
0.292 + sudo apt-get update
0.292 /setup: line 15: sudo: command not found
------
Dockerfile:5
--------------------
   3 |     COPY setup /
   4 |     COPY requirements.txt /
   5 | >>> RUN /setup -y
   6 |     CMD bash
   7 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c /setup -y" did not complete successfully: exit code: 127
Traceback (most recent call last):
  File "./run-docker", line 69, in <module>
    cmd_action_map[args.cmd](args.args)
  File "./run-docker", line 57, in <lambda>
    'create': lambda args: create(args),
  File "./run-docker", line 17, in create
    sh.run_cmd(docker + ['build', '-t', image_name, '.', LF])
  File "shell_helpers.py", line 457, in run_cmd
    raise e
Exception: Command exited with status: 1
```

Looks like, `.dockerenv` file is absent in this case. This should fix that issue.